### PR TITLE
Add missing endpoint specs for spaces usage_summary and isolation seg…

### DIFF
--- a/apis/cf/latest/openapi.yaml
+++ b/apis/cf/latest/openapi.yaml
@@ -446,6 +446,8 @@ paths:
     $ref: './paths/IsolationSegments.yaml#/~1v3~1isolation_segments~1{guid}~1relationships~1organizations~1{org_guid}'
   /v3/isolation_segments/{guid}/relationships/spaces:
     $ref: './paths/IsolationSegments.yaml#/~1v3~1isolation_segments~1{guid}~1relationships~1spaces'
+  /v3/isolation_segments/{guid}/organizations:
+    $ref: './paths/IsolationSegments.yaml#/~1v3~1isolation_segments~1{guid}~1organizations'
   /v3/jobs/{guid}:
     $ref: './paths/Jobs.yaml#/~1v3~1jobs~1{guid}'
   /v3/resource_matches:
@@ -540,6 +542,8 @@ paths:
     $ref: './paths/Spaces.yaml#/~1v3~1spaces~1{guid}~1relationships~1isolation_segment'
   /v3/spaces/{guid}/routes:
     $ref: './paths/Spaces.yaml#/~1v3~1spaces~1{guid}~1routes'
+  /v3/spaces/{guid}/usage_summary:
+    $ref: './paths/Spaces.yaml#/~1v3~1spaces~1{guid}~1usage_summary'
   /v3/spaces/{guid}/running_security_groups:
     $ref: './paths/Spaces.yaml#/~1v3~1spaces~1{guid}~1running_security_groups'
   /v3/spaces/{guid}/staging_security_groups:

--- a/apis/cf/latest/paths/Spaces.yaml
+++ b/apis/cf/latest/paths/Spaces.yaml
@@ -483,6 +483,58 @@
         $ref: '../components/responses/Forbidden.yaml'
       '422':
         $ref: '../components/responses/UnprocessableEntity.yaml'
+/v3/spaces/{guid}/usage_summary:
+  get:
+    summary: Get usage summary for a space
+    description: This endpoint retrieves the specified space's memory and app instance
+      usage summary.
+    operationId: getUsageSummaryForSpace
+    tags:
+    - Spaces
+    parameters:
+    - $ref: '../components/parameters/Guid.yaml'
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                usage_summary:
+                  type: object
+                  properties:
+                    started_instances:
+                      type: integer
+                    memory_in_mb:
+                      type: integer
+                    routes:
+                      type: integer
+                    service_instances:
+                      type: integer
+                    reserved_ports:
+                      type: integer
+                    domains:
+                      type: integer
+                    per_app_tasks:
+                      type: integer
+                    service_keys:
+                      type: integer
+                links:
+                  type: object
+                  properties:
+                    self:
+                      $ref: '../components/schemas/Link.yaml'
+                      description: The URL to get this usage summary
+                    space:
+                      $ref: '../components/schemas/Link.yaml'
+                      description: The URL to get the space for this usage summary
+      '401':
+        $ref: '../components/responses/Unauthorized.yaml'
+      '404':
+        $ref: '../components/responses/NotFound.yaml'
+      '403':
+        $ref: '../components/responses/Forbidden.yaml'
 /v3/spaces/{guid}/running_security_groups:
   get:
     summary: List running security groups for a space


### PR DESCRIPTION
…ment organizations

Two endpoints exist in cloud_controller_ng routes.rb but were missing from the OpenAPI specification:

1. GET /v3/spaces/{guid}/usage_summary - public endpoint analogous to the already-documented GET /v3/organizations/{guid}/usage_summary. Added path definition to Spaces.yaml and wired into openapi.yaml.

2. GET /v3/isolation_segments/{guid}/organizations - path definition already existed in IsolationSegments.yaml but was not referenced from openapi.yaml paths section. Added the $ref to make it visible to spec consumers.

Made-with: Cursor