### PR TITLE
Add GET /v3/processes/{guid}/process_instances endpoint to spec

### DIFF
--- a/apis/cf/latest/openapi.yaml
+++ b/apis/cf/latest/openapi.yaml
@@ -606,6 +606,8 @@ paths:
     $ref: './paths/Processes.yaml#/~1v3~1processes'
   /v3/processes/{guid}:
     $ref: './paths/Processes.yaml#/~1v3~1processes~1{guid}'
+  /v3/processes/{guid}/process_instances:
+    $ref: './paths/Processes.yaml#/~1v3~1processes~1{guid}~1process_instances'
   /v3/processes/{guid}/stats:
     $ref: './paths/Processes.yaml#/~1v3~1processes~1{guid}~1stats'
   /v3/processes/{guid}/actions/scale:

--- a/apis/cf/latest/paths/Processes.yaml
+++ b/apis/cf/latest/paths/Processes.yaml
@@ -147,6 +147,55 @@
         $ref: '../components/responses/ServiceUnavailable.yaml'
       '409':
         $ref: '../components/responses/Conflict.yaml'
+/v3/processes/{guid}/process_instances:
+  get:
+    summary: List instances for a process
+    description: Retrieve the instances for a process. Unlike the stats endpoint,
+      this returns a simplified view with only the index, state, and uptime of each
+      instance.
+    operationId: listProcessInstances
+    tags:
+    - Processes
+    parameters:
+    - $ref: '../components/parameters/Guid.yaml'
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                resources:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      index:
+                        type: integer
+                      state:
+                        type: string
+                        enum:
+                        - RUNNING
+                        - CRASHED
+                        - STARTING
+                        - DOWN
+                      since:
+                        type: number
+                        format: double
+                links:
+                  type: object
+                  properties:
+                    self:
+                      $ref: '../components/schemas/Link.yaml'
+                    process:
+                      $ref: '../components/schemas/Link.yaml'
+      '401':
+        $ref: '../components/responses/Unauthorized.yaml'
+      '404':
+        $ref: '../components/responses/NotFound.yaml'
+      '403':
+        $ref: '../components/responses/Forbidden.yaml'
 /v3/processes/{guid}/stats:
   get:
     summary: Get stats for a process


### PR DESCRIPTION
This endpoint exists in CCNG routes.rb and returns a simplified view of process instances (index, state, since) compared to the /stats endpoint which returns detailed resource usage. Added the path definition to Processes.yaml and wired it into openapi.yaml.

Made-with: Cursor