### PR TITLE
Remove non-existent PUT method from /v3/routes/{guid}/destinations

### DIFF
--- a/apis/cf/latest/paths/Routes.yaml
+++ b/apis/cf/latest/paths/Routes.yaml
@@ -534,45 +534,6 @@
         $ref: '../components/responses/UnprocessableEntity.yaml'
       '404':
         $ref: '../components/responses/NotFound.yaml'
-  put:
-    summary: Replace all destinations for a route
-    description: 'Replaces all destinations for a route, removing any destinations
-      not included in the provided list.
-
-
-      Weighted destinations are **deprecated**. Development of the experimental Istio
-      Service Mesh routing layer was discontinued in 2020 and is no longer supported
-      by the platform. Specifying a `weight` for a destination will take no effect.
-
-
-      If weighted destinations are provided, however, all destinations provided here
-      must have a `weight` specified, and all weights for this route must sum to 100.
-      If not, all provided destinations must not have a `weight`. Mixing weighted
-      and unweighted destinations for a route is not allowed.'
-    operationId: replaceDestinationsForRoute
-    tags:
-    - Routes
-    parameters:
-    - $ref: '../components/parameters/Guid.yaml'
-    requestBody:
-      $ref: '../components/requestBodies/RouteDestinations.yaml'
-    responses:
-      '200':
-        description: List of destinations for the route
-        content:
-          application/json:
-            schema:
-              $ref: '../components/schemas/RouteDestinationList.yaml'
-      '400':
-        $ref: '../components/responses/BadRequest.yaml'
-      '401':
-        $ref: '../components/responses/Unauthorized.yaml'
-      '403':
-        $ref: '../components/responses/Forbidden.yaml'
-      '422':
-        $ref: '../components/responses/UnprocessableEntity.yaml'
-      '500':
-        $ref: '../components/responses/500.yaml'
 /v3/routes/{guid}/destinations/{destination_guid}:
   patch:
     summary: Update a destination protocol for a route


### PR DESCRIPTION
CCNG routes.rb only defines PATCH for replacing route destinations (routes#replace_destinations). The PUT method documented in the spec does not correspond to any route in cloud_controller_ng and would result in a 404 if called. The PATCH method (operationId: replaceDestinationsForRouteWithPatch) remains and is the correct way to replace destinations.

Made-with: Cursor