### PR TITLE
Add IndexLink schema to handle index link's metadata field

### DIFF
--- a/apis/cf/latest/components/schemas/IndexLink.yaml
+++ b/apis/cf/latest/components/schemas/IndexLink.yaml
@@ -1,25 +1,19 @@
-type: object
-properties:
-  href:
-    type: string
-    description: The URL of the link
-  method:
-    type: string
-    description: An optional field containing the HTTP method to be used when following the URL
-  meta:
-    type: object
-    description: Contains metadata about the link
+allOf:
+  - $ref: ../components/schemas/Link.yaml
+  - type: object
     properties:
-      version:
-        type: string
-        description: The version of the API
-      host_key_fingerprint:
-        type: string
-        description: The host key fingerprint of the link
-      oauth_client:
-        type: string
-        description: The oauth client for the link
-required:
-  - href
+      meta:
+        type: object
+        description: Contains metadata about the link
+        properties:
+          version:
+            type: string
+            description: The version of the API
+          host_key_fingerprint:
+            type: string
+            description: The host key fingerprint of the link
+          oauth_client:
+            type: string
+            description: The oauth client for the link
 description: |
   Each link is keyed by its type and will include a href for the URL and an optional method for links that cannot be followed using GET. Can include a meta object with metadata about the link.

--- a/apis/cf/latest/components/schemas/IndexLink.yaml
+++ b/apis/cf/latest/components/schemas/IndexLink.yaml
@@ -1,0 +1,25 @@
+type: object
+properties:
+  href:
+    type: string
+    description: The URL of the link
+  method:
+    type: string
+    description: An optional field containing the HTTP method to be used when following the URL
+  meta:
+    type: object
+    description: Contains metadata about the link
+    properties:
+      version:
+        type: string
+        description: The version of the API
+      host_key_fingerprint:
+        type: string
+        description: The host key fingerprint of the link
+      oauth_client:
+        type: string
+        description: The oauth client for the link
+required:
+  - href
+description: |
+  Each link is keyed by its type and will include a href for the URL and an optional method for links that cannot be followed using GET. Can include a meta object with metadata about the link.

--- a/apis/cf/latest/components/schemas/IndexLink.yaml
+++ b/apis/cf/latest/components/schemas/IndexLink.yaml
@@ -1,5 +1,5 @@
 allOf:
-  - $ref: ../components/schemas/Link.yaml
+  - $ref: ./Link.yaml
   - type: object
     properties:
       meta:

--- a/apis/cf/latest/paths/Root.yaml
+++ b/apis/cf/latest/paths/Root.yaml
@@ -19,35 +19,35 @@ get:
                 properties:
                   self:
                     allOf:
-                      - $ref: '../components/schemas/Link.yaml'
+                      - $ref: '../components/schemas/IndexLink.yaml'
                       - description: Link to the current endpoint
                   cloud_controller_v2:
                     allOf:
-                      - $ref: '../components/schemas/Link.yaml'
+                      - $ref: '../components/schemas/IndexLink.yaml'
                       - description: Link to the Cloud Controller V2 API
                   cloud_controller_v3:
                     allOf:
-                      - $ref: '../components/schemas/Link.yaml'
+                      - $ref: '../components/schemas/IndexLink.yaml'
                       - description: Link to the Cloud Controller V3 API
                   network_policy_v1:
                     allOf:
-                      - $ref: '../components/schemas/Link.yaml'
+                      - $ref: '../components/schemas/IndexLink.yaml'
                       - description: Link to the Network Policy V1 API
                   uaa:
                     allOf:
-                      - $ref: '../components/schemas/Link.yaml'
+                      - $ref: '../components/schemas/IndexLink.yaml'
                       - description: Link to the UAA API
                   logging:
                     allOf:
-                      - $ref: '../components/schemas/Link.yaml'
+                      - $ref: '../components/schemas/IndexLink.yaml'
                       - description: Link to the Logging API
                   log_cache:
                     allOf:
-                      - $ref: '../components/schemas/Link.yaml'
+                      - $ref: '../components/schemas/IndexLink.yaml'
                       - description: Link to the Log Cache API
                   log_stream:
                     allOf:
-                      - $ref: '../components/schemas/Link.yaml'
+                      - $ref: '../components/schemas/IndexLink.yaml'
                       - description: Link to the Log Stream API
     '404':
       $ref: '../components/responses/NotFound.yaml'

--- a/apis/cf/latest/paths/V3.yaml
+++ b/apis/cf/latest/paths/V3.yaml
@@ -19,95 +19,95 @@ get:
                   properties:
                     self:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the current endpoint
                     apps:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the apps endpoint
                     builds:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the builds endpoint
                     deployments:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the deployments endpoint
                     domains:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the domains endpoint
                     droplets:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the droplets endpoint
                     feature_flags:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the feature flags endpoint
                     info:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the info endpoint
                     isolation_segments:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the isolation segments endpoint
                     organizations:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the organizations endpoint
                     packages:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the packages endpoint
                     processes:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the processes endpoint
                     roles:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the roles endpoint
                     routes:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the routes endpoint
                     security_groups:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the security groups endpoint
                     service_brokers:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the service brokers endpoint
                     service_instances:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the service instances endpoint
                     service_offerings:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the service offerings endpoint
                     service_plans:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the service plans endpoint
                     spaces:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the spaces endpoint
                     stacks:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the stacks endpoint
                     tasks:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the tasks endpoint
                     users:
                       allOf:
-                        - $ref: '../components/schemas/Link.yaml'
+                        - $ref: '../components/schemas/IndexLink.yaml'
                         - description: Link to the users endpoint
       '404':
         $ref: '../components/responses/NotFound.yaml'

--- a/apis/cf/latest/paths/V3.yaml
+++ b/apis/cf/latest/paths/V3.yaml
@@ -19,95 +19,95 @@ get:
                   properties:
                     self:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the current endpoint
                     apps:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the apps endpoint
                     builds:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the builds endpoint
                     deployments:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the deployments endpoint
                     domains:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the domains endpoint
                     droplets:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the droplets endpoint
                     feature_flags:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the feature flags endpoint
                     info:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the info endpoint
                     isolation_segments:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the isolation segments endpoint
                     organizations:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the organizations endpoint
                     packages:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the packages endpoint
                     processes:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the processes endpoint
                     roles:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the roles endpoint
                     routes:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the routes endpoint
                     security_groups:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the security groups endpoint
                     service_brokers:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the service brokers endpoint
                     service_instances:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the service instances endpoint
                     service_offerings:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the service offerings endpoint
                     service_plans:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the service plans endpoint
                     spaces:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the spaces endpoint
                     stacks:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the stacks endpoint
                     tasks:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the tasks endpoint
                     users:
                       allOf:
-                        - $ref: '../components/schemas/IndexLink.yaml'
+                        - $ref: '../components/schemas/Link.yaml'
                         - description: Link to the users endpoint
       '404':
         $ref: '../components/responses/NotFound.yaml'


### PR DESCRIPTION
Separate out from the link schema file to not pollute all of the other link objects with an always empty meta object.